### PR TITLE
Refactor code to use Pandas instead of csv

### DIFF
--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -4,6 +4,8 @@ This module contains the class(es) and functions to read the datasets.
 
 """
 import csv
+import pandas as pd
+
 
 
 class Dataset(object):
@@ -33,19 +35,19 @@ class Dataset(object):
 
     def train_set(self):
         """list. Getter method for the training set. """
-        if not self._trainset:  # loads the data to memory once and when requested.
+        if self._trainset is None:  # loads the data to memory once and when requested.
             self._trainset = self.read_dataset(self._trainset_path)
         return self._trainset
 
     def dev_set(self):
         """list. Getter method for the development set. """
-        if not self._devset:  # loads the data to memory once and when requested.
+        if self._devset is None:  # loads the data to memory once and when requested.
             self._devset = self.read_dataset(self._devset_path)
         return self._devset
 
     def test_set(self):
         """list. Getter method for the test set. """
-        if not self._testset:  # loads the data to memory once and when requested.
+        if self._testset is None:  # loads the data to memory once and when requested.
             self._testset = self.read_dataset(self._testset_path)
         return self._testset
 
@@ -63,8 +65,7 @@ class Dataset(object):
         with open(file_path) as file:
             fieldnames = ['hit_id', 'sentence', 'start_offset', 'end_offset', 'target_word', 'native_annots',
                           'nonnative_annots', 'native_complex', 'nonnative_complex', 'gold_label', 'gold_prob']
-            reader = csv.DictReader(file, fieldnames=fieldnames, delimiter='\t')
 
-            dataset = [sent for sent in reader]
+            dataset = pd.read_csv(file, names=fieldnames, sep="\t")
 
         return dataset

--- a/src/models/baseline.py
+++ b/src/models/baseline.py
@@ -52,7 +52,7 @@ class Baseline(object):
         """
         X = []  # to store the extracted features
         y = []  # to store the gold labels
-        for sent in train_set:
+        for i, sent in train_set.iterrows():
             X.append(self.extract_features(sent['target_word']))
             y.append(sent['gold_label'])
 
@@ -70,7 +70,7 @@ class Baseline(object):
 
         """
         X = []  # to store the extracted features
-        for sent in test_set:
+        for i, sent in test_set.iterrows():
             X.append(self.extract_features(sent['target_word']))
 
         return self.model.predict(X)

--- a/src/models/run_baseline.py
+++ b/src/models/run_baseline.py
@@ -27,12 +27,12 @@ def execute_baseline(language, dataset_name):
 
     print("\nResults on Development Data")
     predictions_dev = baseline.predict(data.dev_set())
-    gold_labels_dev = [sent['gold_label'] for sent in data.dev_set()]
+    gold_labels_dev = [sent['gold_label'] for i, sent in data.dev_set().iterrows()]
     print(report_binary_score(gold_labels_dev, predictions_dev))
 
     print("\nResults on Test Data")
     predictions_test = baseline.predict(data.test_set())
-    gold_labels_test = [sent['gold_label'] for sent in data.test_set()]
+    gold_labels_test = [sent['gold_label'] for i, sent in data.test_set().iterrows()]
     print(report_binary_score(gold_labels_test, predictions_test))
 
     print()


### PR DESCRIPTION
In order to use my sklearn pipeline approach we need to use pandas, because it requires extracting all rows in a column at once, eg for target word/gold label etc. As far as I know this is not possible with the csv module, which has to iterate through the rows in a column.

Slight increase in memory overhead using pandas but I think this step is necessary for my approach. 